### PR TITLE
warmabs data fix

### DIFF
--- a/Warmabs/Project.toml
+++ b/Warmabs/Project.toml
@@ -1,7 +1,7 @@
 name = "Warmabs"
 uuid = "1293a30c-8ee5-487f-8299-33928d5cda09"
 authors = ["fjebaker <fergusbkr@gmail.com>"]
-version = "0.1.6"
+version = "0.1.7"
 
 [deps]
 LibXSPEC_Warmabs_jll = "cad11c8d-934b-5dad-a678-9ee9e5e00166"

--- a/Warmabs/src/Warmabs.jl
+++ b/Warmabs/src/Warmabs.jl
@@ -132,6 +132,7 @@ end
 
 const MODEL_FILES = (
     "atdbwarmabs.fits",
+    "coheatwarmabs.dat",
     "xo01_detah2.fits",
     "xo01_detah3.fits",
     "xo01_detah4.fits",


### PR DESCRIPTION
Include `coheatwarmabs.dat` in the list of `MODEL_FILES` that `XS_WarmAbsorber` requires.

Version has already been bumped in anticipation of merging this PR.

Note: this file needs to be added to https://www.star.bris.ac.uk/fergus/xspec/data//warmabs/ before this will work.
